### PR TITLE
ci: fix typo in windows binary name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,14 +27,14 @@ archives:
   - id: default
     ids: [octo]
     formats: [tar.gz]
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "octo_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE.txt
       - README.md
   - id: octo-win
     ids: [octo-win]
     formats: [zip]
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "octo_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE.txt
       - README.md


### PR DESCRIPTION
## ✏️ Summary

This PR fixes a typo in binary names.

## ✅ Checklist

- [x] My code builds and passes tests
- [x] I’ve added or updated CLI help text if needed
- [x] I’ve updated docs (README, etc.) if applicable

## 📎 Related Issues
